### PR TITLE
Shadow-interaction-reworks

### DIFF
--- a/bake-hard/levels/trial_one.tscn
+++ b/bake-hard/levels/trial_one.tscn
@@ -27,7 +27,6 @@ tile_set = ExtResource("1_0olx2")
 navigation_enabled = false
 
 [node name="Enemies" type="Node2D" parent="."]
-visible = false
 
 [node name="Enemy" parent="Enemies" node_paths=PackedStringArray("activation_source") instance=ExtResource("2_2iy0l")]
 position = Vector2(81, 207)

--- a/bake-hard/levels/trial_one.tscn
+++ b/bake-hard/levels/trial_one.tscn
@@ -27,6 +27,7 @@ tile_set = ExtResource("1_0olx2")
 navigation_enabled = false
 
 [node name="Enemies" type="Node2D" parent="."]
+visible = false
 
 [node name="Enemy" parent="Enemies" node_paths=PackedStringArray("activation_source") instance=ExtResource("2_2iy0l")]
 position = Vector2(81, 207)
@@ -248,14 +249,6 @@ zoom = Vector2(2, 2)
 
 [node name="DisplayCase" parent="." instance=ExtResource("3_6fbs3")]
 position = Vector2(160, 209)
-rotation = 4.71239
-
-[node name="InteractLabel" parent="DisplayCase" index="3"]
-offset_left = 74.0
-offset_top = -67.0
-offset_right = 212.0
-offset_bottom = -44.0
-rotation = 1.5708
 
 [node name="CanvasLayer" type="CanvasLayer" parent="."]
 
@@ -309,5 +302,3 @@ tile_set = ExtResource("7_m7c1x")
 [connection signal="level_begin" from="DisplayCase" to="." method="_on_activate_pressed"]
 [connection signal="start_break_cutscene" from="DisplayCase" to="CanvasLayer/LevelStartAnimate" method="play_start_animation"]
 [connection signal="animation_finished" from="CanvasLayer/LevelStartAnimate" to="DisplayCase" method="_break_cutscene_finished"]
-
-[editable path="DisplayCase"]

--- a/bake-hard/scenes/display_case.tscn
+++ b/bake-hard/scenes/display_case.tscn
@@ -10,11 +10,12 @@ size = Vector2(26, 59)
 size = Vector2(51, 109)
 
 [node name="DisplayCase" type="Node2D"]
+rotation = 4.71239
 script = ExtResource("1_c4s7v")
 
-[node name="Collision" type="Area2D" parent="."]
+[node name="StaticBody2D" type="StaticBody2D" parent="."]
 
-[node name="Shape" type="CollisionShape2D" parent="Collision"]
+[node name="CollisionShape2D" type="CollisionShape2D" parent="StaticBody2D"]
 position = Vector2(0, -0.5)
 shape = SubResource("RectangleShape2D_c4s7v")
 
@@ -31,11 +32,13 @@ position = Vector2(15.5, 0.5)
 shape = SubResource("RectangleShape2D_pqt5d")
 
 [node name="InteractLabel" type="Label" parent="."]
-offset_left = -68.0
-offset_top = -69.0
-offset_right = 70.0
-offset_bottom = -46.0
-text = "Interact to RISK IT"
+offset_left = 80.0
+offset_top = -66.0
+offset_right = 218.0
+offset_bottom = -43.0
+rotation = 1.5708
+text = "Fire to START"
+horizontal_alignment = 1
 
 [connection signal="body_entered" from="StartArea" to="." method="_on_start_area_body_entered"]
 [connection signal="body_exited" from="StartArea" to="." method="_on_start_area_body_exited"]

--- a/bake-hard/scenes/enemy.tscn
+++ b/bake-hard/scenes/enemy.tscn
@@ -63,7 +63,7 @@ _data = {
 }
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_4ra3w"]
-radius = 293.171
+radius = 190.003
 
 [node name="Enemy" type="CharacterBody2D"]
 editor_description = "This character collides in layer 01! With walls."

--- a/bake-hard/scenes/enemy.tscn
+++ b/bake-hard/scenes/enemy.tscn
@@ -63,7 +63,7 @@ _data = {
 }
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_4ra3w"]
-radius = 190.003
+radius = 224.009
 
 [node name="Enemy" type="CharacterBody2D"]
 editor_description = "This character collides in layer 01! With walls."

--- a/bake-hard/scenes/objectives_anchor.tscn
+++ b/bake-hard/scenes/objectives_anchor.tscn
@@ -26,21 +26,3 @@ theme_override_constants/margin_left = 40
 
 [node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/Objectives"]
 layout_mode = 2
-
-[node name="Trash" type="RichTextLabel" parent="VBoxContainer/Objectives/VBoxContainer"]
-custom_minimum_size = Vector2(400, 0)
-layout_mode = 2
-text = "Throw out the trash"
-fit_content = true
-
-[node name="Weapon" type="RichTextLabel" parent="VBoxContainer/Objectives/VBoxContainer"]
-custom_minimum_size = Vector2(400, 0)
-layout_mode = 2
-text = "Get a real weapon"
-fit_content = true
-
-[node name="Flour" type="RichTextLabel" parent="VBoxContainer/Objectives/VBoxContainer"]
-custom_minimum_size = Vector2(400, 0)
-layout_mode = 2
-text = "Get the Faerie Flour"
-fit_content = true

--- a/bake-hard/scenes/player.tscn
+++ b/bake-hard/scenes/player.tscn
@@ -5,7 +5,7 @@
 [ext_resource type="Texture2D" uid="uid://brb7lwgtn4w8c" path="res://assets/sprites/chefingham.png" id="3_tuyoq"]
 [ext_resource type="PackedScene" uid="uid://b623nk6koqbhm" path="res://scenes/hit_effect.tscn" id="4_qlg0r"]
 [ext_resource type="AudioStream" uid="uid://brauathg8bofk" path="res://assets/sound/ping.mp3" id="4_tuyoq"]
-[ext_resource type="Script" path="res://scripts/shadow_reveal.gd" id="6_tuyoq"]
+[ext_resource type="Script" uid="uid://byoba1k2sawpr" path="res://scripts/shadow_reveal.gd" id="6_tuyoq"]
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_g2els"]
 
@@ -416,174 +416,174 @@ collision_mask = 17
 target_position = Vector2(320, 120)
 collision_mask = 17
 
-[node name="Sight26" type="RayCast2D" parent="VisionRays"]
+[node name="TrueSight1" type="RayCast2D" parent="VisionRays"]
 target_position = Vector2(29, 16)
-collision_mask = 17
+collision_mask = 16
 
 [node name="Sight27" type="RayCast2D" parent="VisionRays"]
 target_position = Vector2(26, 20)
-collision_mask = 17
+collision_mask = 16
 
 [node name="Sight28" type="RayCast2D" parent="VisionRays"]
 target_position = Vector2(22, 24)
-collision_mask = 17
+collision_mask = 16
 
 [node name="Sight29" type="RayCast2D" parent="VisionRays"]
 rotation = 0.136541
 target_position = Vector2(21.5076, 24.2986)
-collision_mask = 17
+collision_mask = 16
 
 [node name="Sight30" type="RayCast2D" parent="VisionRays"]
 rotation = 0.136541
 target_position = Vector2(16.8264, 26.9606)
-collision_mask = 17
+collision_mask = 16
 
 [node name="Sight31" type="RayCast2D" parent="VisionRays"]
 rotation = 0.136541
 target_position = Vector2(12.1452, 29.6225)
-collision_mask = 17
+collision_mask = 16
 
 [node name="Sight32" type="RayCast2D" parent="VisionRays"]
 rotation = 0.136541
 target_position = Vector2(7.32784, 31.2938)
-collision_mask = 17
+collision_mask = 16
 
 [node name="Sight33" type="RayCast2D" parent="VisionRays"]
 rotation = 0.136541
 target_position = Vector2(3.36507, 31.8383)
-collision_mask = 17
+collision_mask = 16
 
 [node name="Sight34" type="RayCast2D" parent="VisionRays"]
 rotation = 0.136541
 target_position = Vector2(-0.597704, 32.3828)
-collision_mask = 17
+collision_mask = 16
 
 [node name="Sight35" type="RayCast2D" parent="VisionRays"]
 rotation = 0.136541
 target_position = Vector2(-5.68729, 32.0727)
-collision_mask = 17
+collision_mask = 16
 
 [node name="Sight36" type="RayCast2D" parent="VisionRays"]
 rotation = 0.136541
 target_position = Vector2(-9.92229, 30.6357)
-collision_mask = 17
+collision_mask = 16
 
 [node name="Sight37" type="RayCast2D" parent="VisionRays"]
 rotation = 0.136541
 target_position = Vector2(-14.1573, 29.1988)
-collision_mask = 17
+collision_mask = 16
 
 [node name="Sight38" type="RayCast2D" parent="VisionRays"]
 rotation = 0.136541
 target_position = Vector2(-18.5284, 26.7712)
-collision_mask = 17
+collision_mask = 16
 
 [node name="Sight39" type="RayCast2D" parent="VisionRays"]
 rotation = 0.136541
 target_position = Vector2(-21.9089, 24.2075)
-collision_mask = 17
+collision_mask = 16
 
 [node name="Sight40" type="RayCast2D" parent="VisionRays"]
 rotation = 0.136541
 target_position = Vector2(-25.4254, 20.6531)
-collision_mask = 17
+collision_mask = 16
 
 [node name="Sight41" type="RayCast2D" parent="VisionRays"]
 rotation = 0.136541
 target_position = Vector2(-27.9513, 16.9625)
-collision_mask = 17
+collision_mask = 16
 
 [node name="Sight42" type="RayCast2D" parent="VisionRays"]
 rotation = 0.136541
 target_position = Vector2(-30.6132, 12.2813)
-collision_mask = 17
+collision_mask = 16
 
 [node name="Sight43" type="RayCast2D" parent="VisionRays"]
 rotation = 0.136541
 target_position = Vector2(-32.4206, 6.47326)
-collision_mask = 17
+collision_mask = 16
 
 [node name="Sight44" type="RayCast2D" parent="VisionRays"]
 rotation = 0.136541
 target_position = Vector2(-33.2373, 0.529106)
-collision_mask = 17
+collision_mask = 16
 
 [node name="Sight45" type="RayCast2D" parent="VisionRays"]
 rotation = 0.136541
 target_position = Vector2(-32.9272, -4.56047)
-collision_mask = 17
+collision_mask = 16
 
 [node name="Sight46" type="RayCast2D" parent="VisionRays"]
 rotation = 0.136541
 target_position = Vector2(-31.6264, -9.78617)
-collision_mask = 17
+collision_mask = 16
 
 [node name="Sight47" type="RayCast2D" parent="VisionRays"]
 rotation = 0.136541
 target_position = Vector2(-29.3349, -15.148)
-collision_mask = 17
+collision_mask = 16
 
 [node name="Sight48" type="RayCast2D" parent="VisionRays"]
 rotation = 0.136541
 target_position = Vector2(-26.9073, -19.5191)
-collision_mask = 17
+collision_mask = 16
 
 [node name="Sight49" type="RayCast2D" parent="VisionRays"]
 rotation = 0.136541
 target_position = Vector2(-23.489, -24.0264)
-collision_mask = 17
+collision_mask = 16
 
 [node name="Sight50" type="RayCast2D" parent="VisionRays"]
 rotation = 0.136541
 target_position = Vector2(-18.9439, -27.679)
-collision_mask = 17
+collision_mask = 16
 
 [node name="Sight51" type="RayCast2D" parent="VisionRays"]
 rotation = 0.136541
 target_position = Vector2(-14.2627, -30.341)
-collision_mask = 17
+collision_mask = 16
 
 [node name="Sight52" type="RayCast2D" parent="VisionRays"]
 rotation = 0.136541
 target_position = Vector2(-9.44534, -32.0123)
-collision_mask = 17
+collision_mask = 16
 
 [node name="Sight53" type="RayCast2D" parent="VisionRays"]
 rotation = 0.136541
 target_position = Vector2(-4.628, -33.6836)
-collision_mask = 17
+collision_mask = 16
 
 [node name="Sight54" type="RayCast2D" parent="VisionRays"]
 rotation = 0.136541
 target_position = Vector2(0.461586, -33.3735)
-collision_mask = 17
+collision_mask = 16
 
 [node name="Sight55" type="RayCast2D" parent="VisionRays"]
 rotation = 0.136541
 target_position = Vector2(6.67798, -32.2088)
-collision_mask = 17
+collision_mask = 16
 
 [node name="Sight56" type="RayCast2D" parent="VisionRays"]
 rotation = 0.136541
 target_position = Vector2(12.0398, -29.9173)
-collision_mask = 17
+collision_mask = 16
 
 [node name="Sight57" type="RayCast2D" parent="VisionRays"]
 rotation = 0.136541
 target_position = Vector2(17.5377, -26.6351)
-collision_mask = 17
+collision_mask = 16
 
 [node name="Sight58" type="RayCast2D" parent="VisionRays"]
 rotation = 0.136541
 target_position = Vector2(22.045, -23.2168)
-collision_mask = 17
+collision_mask = 16
 
 [node name="Sight59" type="RayCast2D" parent="VisionRays"]
 rotation = 0.136541
 target_position = Vector2(25.5615, -19.6624)
-collision_mask = 17
+collision_mask = 16
 
 [node name="Sight60" type="RayCast2D" parent="VisionRays"]
 rotation = 0.136541
 target_position = Vector2(28.0874, -15.9718)
-collision_mask = 17
+collision_mask = 16

--- a/bake-hard/scenes/player.tscn
+++ b/bake-hard/scenes/player.tscn
@@ -415,3 +415,175 @@ collision_mask = 17
 [node name="Sight25" type="RayCast2D" parent="VisionRays"]
 target_position = Vector2(320, 120)
 collision_mask = 17
+
+[node name="Sight26" type="RayCast2D" parent="VisionRays"]
+target_position = Vector2(29, 16)
+collision_mask = 17
+
+[node name="Sight27" type="RayCast2D" parent="VisionRays"]
+target_position = Vector2(26, 20)
+collision_mask = 17
+
+[node name="Sight28" type="RayCast2D" parent="VisionRays"]
+target_position = Vector2(22, 24)
+collision_mask = 17
+
+[node name="Sight29" type="RayCast2D" parent="VisionRays"]
+rotation = 0.136541
+target_position = Vector2(21.5076, 24.2986)
+collision_mask = 17
+
+[node name="Sight30" type="RayCast2D" parent="VisionRays"]
+rotation = 0.136541
+target_position = Vector2(16.8264, 26.9606)
+collision_mask = 17
+
+[node name="Sight31" type="RayCast2D" parent="VisionRays"]
+rotation = 0.136541
+target_position = Vector2(12.1452, 29.6225)
+collision_mask = 17
+
+[node name="Sight32" type="RayCast2D" parent="VisionRays"]
+rotation = 0.136541
+target_position = Vector2(7.32784, 31.2938)
+collision_mask = 17
+
+[node name="Sight33" type="RayCast2D" parent="VisionRays"]
+rotation = 0.136541
+target_position = Vector2(3.36507, 31.8383)
+collision_mask = 17
+
+[node name="Sight34" type="RayCast2D" parent="VisionRays"]
+rotation = 0.136541
+target_position = Vector2(-0.597704, 32.3828)
+collision_mask = 17
+
+[node name="Sight35" type="RayCast2D" parent="VisionRays"]
+rotation = 0.136541
+target_position = Vector2(-5.68729, 32.0727)
+collision_mask = 17
+
+[node name="Sight36" type="RayCast2D" parent="VisionRays"]
+rotation = 0.136541
+target_position = Vector2(-9.92229, 30.6357)
+collision_mask = 17
+
+[node name="Sight37" type="RayCast2D" parent="VisionRays"]
+rotation = 0.136541
+target_position = Vector2(-14.1573, 29.1988)
+collision_mask = 17
+
+[node name="Sight38" type="RayCast2D" parent="VisionRays"]
+rotation = 0.136541
+target_position = Vector2(-18.5284, 26.7712)
+collision_mask = 17
+
+[node name="Sight39" type="RayCast2D" parent="VisionRays"]
+rotation = 0.136541
+target_position = Vector2(-21.9089, 24.2075)
+collision_mask = 17
+
+[node name="Sight40" type="RayCast2D" parent="VisionRays"]
+rotation = 0.136541
+target_position = Vector2(-25.4254, 20.6531)
+collision_mask = 17
+
+[node name="Sight41" type="RayCast2D" parent="VisionRays"]
+rotation = 0.136541
+target_position = Vector2(-27.9513, 16.9625)
+collision_mask = 17
+
+[node name="Sight42" type="RayCast2D" parent="VisionRays"]
+rotation = 0.136541
+target_position = Vector2(-30.6132, 12.2813)
+collision_mask = 17
+
+[node name="Sight43" type="RayCast2D" parent="VisionRays"]
+rotation = 0.136541
+target_position = Vector2(-32.4206, 6.47326)
+collision_mask = 17
+
+[node name="Sight44" type="RayCast2D" parent="VisionRays"]
+rotation = 0.136541
+target_position = Vector2(-33.2373, 0.529106)
+collision_mask = 17
+
+[node name="Sight45" type="RayCast2D" parent="VisionRays"]
+rotation = 0.136541
+target_position = Vector2(-32.9272, -4.56047)
+collision_mask = 17
+
+[node name="Sight46" type="RayCast2D" parent="VisionRays"]
+rotation = 0.136541
+target_position = Vector2(-31.6264, -9.78617)
+collision_mask = 17
+
+[node name="Sight47" type="RayCast2D" parent="VisionRays"]
+rotation = 0.136541
+target_position = Vector2(-29.3349, -15.148)
+collision_mask = 17
+
+[node name="Sight48" type="RayCast2D" parent="VisionRays"]
+rotation = 0.136541
+target_position = Vector2(-26.9073, -19.5191)
+collision_mask = 17
+
+[node name="Sight49" type="RayCast2D" parent="VisionRays"]
+rotation = 0.136541
+target_position = Vector2(-23.489, -24.0264)
+collision_mask = 17
+
+[node name="Sight50" type="RayCast2D" parent="VisionRays"]
+rotation = 0.136541
+target_position = Vector2(-18.9439, -27.679)
+collision_mask = 17
+
+[node name="Sight51" type="RayCast2D" parent="VisionRays"]
+rotation = 0.136541
+target_position = Vector2(-14.2627, -30.341)
+collision_mask = 17
+
+[node name="Sight52" type="RayCast2D" parent="VisionRays"]
+rotation = 0.136541
+target_position = Vector2(-9.44534, -32.0123)
+collision_mask = 17
+
+[node name="Sight53" type="RayCast2D" parent="VisionRays"]
+rotation = 0.136541
+target_position = Vector2(-4.628, -33.6836)
+collision_mask = 17
+
+[node name="Sight54" type="RayCast2D" parent="VisionRays"]
+rotation = 0.136541
+target_position = Vector2(0.461586, -33.3735)
+collision_mask = 17
+
+[node name="Sight55" type="RayCast2D" parent="VisionRays"]
+rotation = 0.136541
+target_position = Vector2(6.67798, -32.2088)
+collision_mask = 17
+
+[node name="Sight56" type="RayCast2D" parent="VisionRays"]
+rotation = 0.136541
+target_position = Vector2(12.0398, -29.9173)
+collision_mask = 17
+
+[node name="Sight57" type="RayCast2D" parent="VisionRays"]
+rotation = 0.136541
+target_position = Vector2(17.5377, -26.6351)
+collision_mask = 17
+
+[node name="Sight58" type="RayCast2D" parent="VisionRays"]
+rotation = 0.136541
+target_position = Vector2(22.045, -23.2168)
+collision_mask = 17
+
+[node name="Sight59" type="RayCast2D" parent="VisionRays"]
+rotation = 0.136541
+target_position = Vector2(25.5615, -19.6624)
+collision_mask = 17
+
+[node name="Sight60" type="RayCast2D" parent="VisionRays"]
+rotation = 0.136541
+target_position = Vector2(28.0874, -15.9718)
+collision_mask = 17

--- a/bake-hard/scripts/enemy.gd
+++ b/bake-hard/scripts/enemy.gd
@@ -46,6 +46,8 @@ func _process(_delta: float) -> void:
 			var end_pos = body.global_position
 			var space_state = get_world_2d().direct_space_state
 			var ray_params = PhysicsRayQueryParameters2D.new()
+			# 0b00000000_00000000_00000000_00000011
+			ray_params.collision_mask = 3 # Collision mask 2, 1
 			ray_params.from = start_pos
 			ray_params.to = end_pos
 			ray_params.exclude = [self]

--- a/bake-hard/scripts/player.gd
+++ b/bake-hard/scripts/player.gd
@@ -45,6 +45,7 @@ func _input(event):
 			var end_pos = start_pos + Vector2.RIGHT.rotated(rotation) * ray_length
 			var space_state = get_world_2d().direct_space_state
 			var ray_params = PhysicsRayQueryParameters2D.new()
+			ray_params.collision_mask = 1 # Collide with walls and charbodies, only
 			ray_params.from = start_pos
 			ray_params.to = end_pos
 			ray_params.exclude = [self]

--- a/bake-hard/scripts/player.gd
+++ b/bake-hard/scripts/player.gd
@@ -45,7 +45,8 @@ func _input(event):
 			var end_pos = start_pos + Vector2.RIGHT.rotated(rotation) * ray_length
 			var space_state = get_world_2d().direct_space_state
 			var ray_params = PhysicsRayQueryParameters2D.new()
-			ray_params.collision_mask = 1 # Collide with walls and charbodies, only
+			# 0b00000000_00000000_00000000_00000101
+			ray_params.collision_mask = 5 # Collide with walls and enemies
 			ray_params.from = start_pos
 			ray_params.to = end_pos
 			ray_params.exclude = [self]


### PR DESCRIPTION
Shadows were being collided with on space_state ray checks. This is because the ray_aprams include a masking value represented as a bitmask, which is masking all layers by default.

Player attack now masks walls and enemies.

Enemy vision check for line of sight now only collides with walls and the player.

BONUS The display case was not acting as a collision object, and the objectives window had placeholder values. Placeholders are gone, and display case collides again.